### PR TITLE
fix!: gradle plugin use project name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,13 +5,13 @@ plugins {
     idea
     kotlin("jvm") version "1.6.21"
     id("org.jetbrains.dokka") version "1.6.21"
-    id("se.ascp.gradle.gradle-versions-filter") version "0.1.13+"
+    id("se.ascp.gradle.gradle-versions-filter") version "0.1.14"
     id("org.jmailen.kotlinter") version "3.10.0"
     id("org.owasp.dependencycheck") version "7.1.0.1"
     // id("com.jfrog.artifactory") version "4.26.1"
     // id("com.gradle.plugin-publish") version "0.18.0"
     id("pl.allegro.tech.build.axion-release") version "1.13.6"
-    id("se.svt.oss.gradle-yapp-publisher-plugin") version "0.1.15+"
+    id("se.svt.oss.gradle-yapp-publisher-plugin") version "0.1.16"
 }
 
 group = "se.svt.oss"

--- a/src/main/kotlin/se/svt/oss/gradle/yapp/plugin/GradlePortalPublishingPlugin.kt
+++ b/src/main/kotlin/se/svt/oss/gradle/yapp/plugin/GradlePortalPublishingPlugin.kt
@@ -52,7 +52,7 @@ internal class GradlePortalPublishingPlugin(project: Project) : BasePlugin(proje
                         as MavenPublication
                     val pluginId = declaration.id
                     val pluginGroupId = coordinates.groupId
-                    val pluginArtifactId = project.rootProject.name
+                    val pluginArtifactId = project.name
 
                     println("$pluginGroupId $pluginId $pluginArtifactId")
                     val pluginVersion = coordinates.version


### PR DESCRIPTION
Set the gradle portal artifact id to project name instead of rootproject name.

Signed-off-by: Josef Andersson <josef.andersson@svt.se>

